### PR TITLE
Update zerostream.js

### DIFF
--- a/bin/zerostream.js
+++ b/bin/zerostream.js
@@ -1,7 +1,7 @@
 var stream = require('stream')
 var inherits = require('util').inherits
 
-var BLANK = new Buffer(65536)
+var BLANK = Buffer.alloc(65536)
 BLANK.fill(0)
 
 module.exports = ZeroStream


### PR DESCRIPTION
Due to: (node:63068) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.